### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -9,7 +9,7 @@ This API uses the Python [Connexion](https://github.com/zalando/connexion) libra
 Python 3.7+
 neo4j 1.7.0+
 numpy 1.18+
-fuzzywuzzy 0.18+
+rapidfuzz 0.2.1+
 requests 2.23+
 
 ## Data Requirements

--- a/app/evidara_api/biggim.py
+++ b/app/evidara_api/biggim.py
@@ -6,7 +6,7 @@ import time
 from contextlib import closing
 
 import requests
-from fuzzywuzzy.process import extractOne
+from rapidfuzz.process import extractOne
 from werkzeug.utils import cached_property
 
 from evidara_api.models.edge_attribute import EdgeAttribute

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -2,11 +2,10 @@ connexion >= 2.5.0; python_version>="3.6"
 connexion >= 2.3.0; python_version=="3.5"
 connexion >= 2.3.0; python_version=="3.4"
 connexion == 2.4.0; python_version<="2.7"
-fuzzywuzzy == 0.18
+rapidfuzz == 0.2.1
 neo4j == 1.7.0
 numpy == 1.18.1
 python_dateutil >= 2.6.0
-python-Levenshtein == 0.12
 requests == 2.23.0
 setuptools >= 21.0.0
 swagger-ui-bundle >= 0.0.2


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.